### PR TITLE
Adds LibreMiami Guix

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ A curated list of awesome meetups around the globe
   - [Chicago Java User’s Group](http://www.meetup.com/ChicagoJUG/)
 - Denver
   - [DenverJUG](http://www.denverjug.org/)
+- Miami
+  - [LibreMiami Guix](https://libremiami.org/#events)


### PR DESCRIPTION
This commit adds a [guix](http://guix.gnu.org/) online meetup that is hosted every last Saturday of every month  from 2pm – 4pm EST @ [LibreMiami Mumble](http://mumble.libremiami.org/).

The group gets together regularly to package and update software for upstream as well as to onboard new contributors.

> Guix is a cross-platform package manager and a tool to instantiate and manage Unix-like operating systems, based on the Nix package manager with Guile Scheme APIs and specializes in providing exclusively free software.

[What Is Guix Really?](https://www.ryanprior.com/posts/what-is-guix-really/)